### PR TITLE
Fix/lexer

### DIFF
--- a/sources/lexer.c
+++ b/sources/lexer.c
@@ -86,7 +86,7 @@ static char	*word_last_char(char *command_line)
 			return (command_line + 1);
 	}
 	if (ft_strchr(QUOTES, *command_line))
-		return (quote_deal(command_line));
+		command_line = quote_deal(command_line));
 	while (*command_line && !ft_strchr(TAB_OR_SPACE, *command_line)
 		&& !ft_strchr(METACHR_NO_AND, *command_line))
 	{

--- a/sources/strip_quotes.c
+++ b/sources/strip_quotes.c
@@ -67,7 +67,7 @@ char	*strip_quotes(char *expanded_cmd)
 	while (expanded_cmd[i])
 	{
 		if (expanded_cmd[i] == '"' || expanded_cmd[i] == '\'')
-			(fill_unquoted_string(expanded_cmd, &i, unquoted_str, &j));
+			fill_unquoted_string(expanded_cmd, &i, unquoted_str, &j);
 		else
 			unquoted_str[j++] = expanded_cmd[i++];
 	}


### PR DESCRIPTION
- Fixes the quoted tokenization when string literals is not separed to other words.

CMD: echo '  '42
Old behaviour: token.values = {echo, '  ', 42}
New behaviour: token.values = {echo, '  '42}