### PR TITLE
Refactor path setting, relocate isvalid_num and "(" leak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: pmelo-ca <pmelo-ca@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/02/14 11:17:20 by jovicto2          #+#    #+#              #
-#    Updated: 2024/09/12 19:15:55 by pmelo-ca         ###   ########.fr        #
+#    Updated: 2024/09/16 11:57:09 by pmelo-ca         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -29,7 +29,37 @@ MKDIR					:= mkdir -p
 RM						:= rm -rf
 
 # Sources
-FILES					:= minishell minishell_init parser parser_flag_utils parser_utils builtins builtins_utils cd_utils cd echo env exec clear_aux clear_minishell clean_string_utils exec_utils exit export pwd redirects unset lexer expand expand_utils split_cmd strip_quotes signal signal_heredoc heredoc_utils utils
+FILES := minishell \
+	minishell_init \
+	parser \
+	parser_flag_utils \
+	parser_utils \
+	builtins \
+	builtins_utils \
+	cd_utils \
+	cd \
+	echo \
+	env \
+	exec \
+	clear_aux \
+	clear_minishell \
+	clean_string_utils \
+	exec_utils \
+	exit \
+	export \
+	pwd \
+	redirects \
+	unset \
+	lexer \
+	expand \
+	expand_utils \
+	split_cmd \
+	strip_quotes \
+	signal \
+	signal_heredoc \
+	heredoc_utils \
+	utils
+
 SOURCES					:= $(addprefix $(SOURCES_DIR), $(addsuffix .c, $(FILES)))
 OBJECTS					:= $(addprefix $(OBJECTS_DIR), $(addsuffix .o, $(FILES)))
 LIBFT					:= $(addprefix $(LIBFT_DIR), $(LIBFT_FILE))

--- a/readline.sup
+++ b/readline.sup
@@ -1,0 +1,62 @@
+{
+   <Readline>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:readline
+   ...
+}
+{
+   <Readline>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:xmalloc
+   fun:rl_add_undo
+   fun:rl_insert_text
+   fun:_rl_insert_char
+   fun:rl_insert
+   fun:_rl_dispatch_subseq
+   fun:readline_internal_char
+   fun:readline
+   ...
+}
+{
+   <AddHistory>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:xmalloc
+   fun:add_history
+   ...
+}
+{
+   <AddHistory>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:xmalloc
+   fun:alloc_history_entry
+   fun:add_history
+   ...
+}
+{
+   <AddHistory>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:xmalloc
+   fun:UnknownInlinedFun
+   fun:add_history
+   ...
+}
+{
+   <ReadlineInternalTeardown>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:xmalloc
+   fun:readline_internal_teardown
+   fun:readline
+   ...
+}

--- a/sources/exec_utils.c
+++ b/sources/exec_utils.c
@@ -14,6 +14,7 @@
 
 static void	exit_handler_aux(char *message, char *command,
 				t_minishell **minishell, int exit_status);
+static void	set_path(char **minishell_path, char *new_path);
 
 void	get_path(t_minishell **minishell, t_ast *node)
 {
@@ -36,12 +37,19 @@ void	get_path(t_minishell **minishell, t_ast *node)
 		if (!(access(possible_path, X_OK)))
 		{
 			clean_child_data(paths, NULL, part_path);
-			(*minishell)->path = possible_path;
+			set_path(&(*minishell)->path, possible_path);
 			return ;
 		}
 		clean_child_data(NULL, possible_path, part_path);
 	}
 	clear_matrix(paths);
+}
+
+static void	set_path(char **minishell_path, char *new_path)
+{
+	if (*minishell_path)
+		free(*minishell_path);
+	*minishell_path = new_path;
 }
 
 void	exit_handler(t_minishell **minishell, t_ast *node)
@@ -66,28 +74,6 @@ void	reset_redirects(bool piped, t_minishell *minishell)
 		return ;
 	dup2(minishell->stdin, 0);
 	dup2(minishell->stdout, 1);
-}
-
-bool	isvalid_num(char *command)
-{
-	long long	c;
-	char		*string;
-
-	if (command[0] == '+' || command[0] == '-')
-		command++;
-	if (isnumber(command))
-	{
-		c = atoll(command);
-		string = lltoa(c);
-		if (ft_strncmp(string, command, ft_strlen(command)) == 0)
-		{
-			free(string);
-			return (true);
-		}
-		free(string);
-		return (false);
-	}
-	return (false);
 }
 
 static void	exit_handler_aux(char *message, char *command,

--- a/sources/parser.c
+++ b/sources/parser.c
@@ -69,10 +69,12 @@ static t_ast	*create_ast_leaf(t_dlist **words, t_parse_status *status)
 	if (status->current != NO_ERROR || !words)
 		return (NULL);
 	if (is_binary_operator((*words)->content) || is_flag((*words)->content,
-			R_PAR) || is_flag((*words)->content, L_PAR))
+			R_PAR))
 		return (set_parse_status(status, SYNTAX_ERROR, *words), NULL);
 	if (is_flag((*words)->content, L_PAR))
 	{
+		if(!(*words)->next)
+			return (set_parse_status(status, SYNTAX_ERROR, *words), NULL);
 		*words = (*words)->next;
 		node = parse_to_ast(words, status, 0);
 		if (!node)

--- a/sources/parser.c
+++ b/sources/parser.c
@@ -6,7 +6,7 @@
 /*   By: pmelo-ca <pmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/20 17:13:07 by pmelo-ca          #+#    #+#             */
-/*   Updated: 2024/09/13 16:59:20 by pmelo-ca         ###   ########.fr       */
+/*   Updated: 2024/09/16 11:41:01 by pmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -73,7 +73,7 @@ static t_ast	*create_ast_leaf(t_dlist **words, t_parse_status *status)
 		return (set_parse_status(status, SYNTAX_ERROR, *words), NULL);
 	if (is_flag((*words)->content, L_PAR))
 	{
-		if(!(*words)->next)
+		if (!(*words)->next)
 			return (set_parse_status(status, SYNTAX_ERROR, *words), NULL);
 		*words = (*words)->next;
 		node = parse_to_ast(words, status, 0);

--- a/sources/parser.c
+++ b/sources/parser.c
@@ -69,9 +69,9 @@ static t_ast	*create_ast_leaf(t_dlist **words, t_parse_status *status)
 	if (status->current != NO_ERROR || !words)
 		return (NULL);
 	if (is_binary_operator((*words)->content) || is_flag((*words)->content,
-			R_PAR))
+			R_PAR) || is_flag((*words)->content, L_PAR))
 		return (set_parse_status(status, SYNTAX_ERROR, *words), NULL);
-	else if (is_flag((*words)->content, L_PAR))
+	if (is_flag((*words)->content, L_PAR))
 	{
 		*words = (*words)->next;
 		node = parse_to_ast(words, status, 0);

--- a/sources/unset.c
+++ b/sources/unset.c
@@ -100,3 +100,25 @@ static int	check_key_unset(char *string)
 	}
 	return (1);
 }
+
+bool	isvalid_num(char *command)
+{
+	long long	c;
+	char		*string;
+
+	if (command[0] == '+' || command[0] == '-')
+		command++;
+	if (isnumber(command))
+	{
+		c = atoll(command);
+		string = lltoa(c);
+		if (ft_strncmp(string, command, ft_strlen(command)) == 0)
+		{
+			free(string);
+			return (true);
+		}
+		free(string);
+		return (false);
+	}
+	return (false);
+}


### PR DESCRIPTION
Moved isvalid_num function from exec_utils.c to unset.c to improve module cohesion.

 Refactored path assignment logic by introducing set_path function to manage memory allocation and avoid memory leaks. 

Enhanced readability and maintainability by consolidating logical operations.

Fix case when "(" caused leaks